### PR TITLE
Add settings for Max DL concurrency + User-Agent

### DIFF
--- a/client/settings.html
+++ b/client/settings.html
@@ -105,10 +105,13 @@
             <input type="url" class="u-full-width"  name="baseUrl" v-model="baseUrl">
         </label>
         <label for="maxDownloadConcurrency" style="display: inline-block;" >
-            <span class="label-body">Limit the number of podcasts that can be downloaded simultaneously.</span>
+            <span class="label-body">Limit the number of podcasts that can be downloaded simultaneously</span>
             <input type="number" name="maxDownloadConcurrency" v-model.number="maxDownloadConcurrency" min="1">
         </label>
-        
+        <label for="userAgent" style="display: inline-block;" >
+            <span class="label-body">Specify the User-Agent header specified when downloading podcasts</span>
+            <input type="text" name="userAgent" v-model="userAgent">
+        </label>
       
         <input type="submit" value="Save" class="button">
     </form>
@@ -187,6 +190,7 @@ var app = new Vue({
             dontDownloadDeletedFromDisk:self.dontDownloadDeletedFromDisk,
             baseUrl:self.baseUrl,
             maxDownloadConcurrency:self.maxDownloadConcurrency,
+            userAgent:self.userAgent,
         })
         .then(function(response){
             Vue.toasted.show('Settings saved successfully.' ,{
@@ -232,6 +236,7 @@ var app = new Vue({
     dontDownloadDeletedFromDisk:{{ .setting.DontDownloadDeletedFromDisk }},
     baseUrl: {{ .setting.BaseUrl }},
     maxDownloadConcurrency:{{ .setting.MaxDownloadConcurrency }},
+    userAgent:{{ .setting.UserAgent}},
   },
 
 })

--- a/client/settings.html
+++ b/client/settings.html
@@ -104,6 +104,10 @@
             <span class="label-body">Base URL (if accessing Podgrab using a URL. Without trailing /. Leave empty if not using or unsure.)</span>
             <input type="url" class="u-full-width"  name="baseUrl" v-model="baseUrl">
         </label>
+        <label for="maxDownloadConcurrency">
+            <input type="number" name="maxDownloadConcurrency" v-model="maxDownloadConcurrency">
+            <span class="label-body">Limit the number of podcasts that can be downloaded simultaneously.</span>
+        </label>
         
       
         <input type="submit" value="Save" class="button">
@@ -181,6 +185,7 @@ var app = new Vue({
             downloadEpisodeImages:self.downloadEpisodeImages,
             generateNFOFile:self.generateNFOFile,
             dontDownloadDeletedFromDisk:self.dontDownloadDeletedFromDisk,
+            maxDownloadConcurrency:self.maxDownloadConcurrency,
             baseUrl:self.baseUrl,
         })
         .then(function(response){
@@ -225,6 +230,7 @@ var app = new Vue({
     downloadEpisodeImages:{{.setting.DownloadEpisodeImages }},
     generateNFOFile:{{ .setting.GenerateNFOFile }},
     dontDownloadDeletedFromDisk:{{ .setting.DontDownloadDeletedFromDisk }},
+    maxDownloadConcurrency:{{ .setting.maxDownloadConcurrency }},
     baseUrl: {{ .setting.BaseUrl }},
   },
 

--- a/client/settings.html
+++ b/client/settings.html
@@ -109,7 +109,7 @@
             <input type="number" name="maxDownloadConcurrency" v-model.number="maxDownloadConcurrency" min="1">
         </label>
         <label for="userAgent" style="display: inline-block;" >
-            <span class="label-body">Specify the User-Agent header specified when downloading podcasts</span>
+            <span class="label-body"The <code>User-Agent</code> header used when downloading podcasts</span>
             <input type="text" class="u-full-width" name="userAgent" v-model="userAgent">
         </label>
       

--- a/client/settings.html
+++ b/client/settings.html
@@ -231,7 +231,7 @@ var app = new Vue({
     generateNFOFile:{{ .setting.GenerateNFOFile }},
     dontDownloadDeletedFromDisk:{{ .setting.DontDownloadDeletedFromDisk }},
     baseUrl: {{ .setting.BaseUrl }},
-    maxDownloadConcurrency:{{ .setting.maxDownloadConcurrency }},
+    maxDownloadConcurrency:{{ .setting.MaxDownloadConcurrency }},
   },
 
 })

--- a/client/settings.html
+++ b/client/settings.html
@@ -109,7 +109,7 @@
             <input type="number" name="maxDownloadConcurrency" v-model.number="maxDownloadConcurrency" min="1">
         </label>
         <label for="userAgent" style="display: inline-block;" >
-            <span class="label-body"The <code>User-Agent</code> header used when downloading podcasts</span>
+            <span class="label-body">The <code>User-Agent</code> header used when downloading podcasts</span>
             <input type="text" class="u-full-width" name="userAgent" v-model="userAgent">
         </label>
       

--- a/client/settings.html
+++ b/client/settings.html
@@ -110,7 +110,7 @@
         </label>
         <label for="userAgent" style="display: inline-block;" >
             <span class="label-body">Specify the User-Agent header specified when downloading podcasts</span>
-            <input type="text" name="userAgent" v-model="userAgent">
+            <input type="text" class="u-full-width" name="userAgent" v-model="userAgent">
         </label>
       
         <input type="submit" value="Save" class="button">

--- a/client/settings.html
+++ b/client/settings.html
@@ -104,9 +104,9 @@
             <span class="label-body">Base URL (if accessing Podgrab using a URL. Without trailing /. Leave empty if not using or unsure.)</span>
             <input type="url" class="u-full-width"  name="baseUrl" v-model="baseUrl">
         </label>
-        <label for="maxDownloadConcurrency">
-            <input type="number" name="maxDownloadConcurrency" v-model="maxDownloadConcurrency">
+        <label for="maxDownloadConcurrency" style="display: inline-block;" >
             <span class="label-body">Limit the number of podcasts that can be downloaded simultaneously.</span>
+            <input type="number" name="maxDownloadConcurrency" v-model.number="maxDownloadConcurrency" min="1">
         </label>
         
       
@@ -185,8 +185,8 @@ var app = new Vue({
             downloadEpisodeImages:self.downloadEpisodeImages,
             generateNFOFile:self.generateNFOFile,
             dontDownloadDeletedFromDisk:self.dontDownloadDeletedFromDisk,
-            maxDownloadConcurrency:self.maxDownloadConcurrency,
             baseUrl:self.baseUrl,
+            maxDownloadConcurrency:self.maxDownloadConcurrency,
         })
         .then(function(response){
             Vue.toasted.show('Settings saved successfully.' ,{
@@ -230,8 +230,8 @@ var app = new Vue({
     downloadEpisodeImages:{{.setting.DownloadEpisodeImages }},
     generateNFOFile:{{ .setting.GenerateNFOFile }},
     dontDownloadDeletedFromDisk:{{ .setting.DontDownloadDeletedFromDisk }},
-    maxDownloadConcurrency:{{ .setting.maxDownloadConcurrency }},
     baseUrl: {{ .setting.BaseUrl }},
+    maxDownloadConcurrency:{{ .setting.maxDownloadConcurrency }},
   },
 
 })

--- a/controllers/pages.go
+++ b/controllers/pages.go
@@ -31,7 +31,7 @@ type SettingModel struct {
 	GenerateNFOFile               bool   `form:"generateNFOFile" json:"generateNFOFile" query:"generateNFOFile"`
 	DontDownloadDeletedFromDisk   bool   `form:"dontDownloadDeletedFromDisk" json:"dontDownloadDeletedFromDisk" query:"dontDownloadDeletedFromDisk"`
 	BaseUrl                       string `form:"baseUrl" json:"baseUrl" query:"baseUrl"`
-	MaxDownloadConcurrency        bool   `form:"maxDownloadConcurrency" json:"maxDownloadConcurrency" query:"maxDownloadConcurrency"`
+	MaxDownloadConcurrency        int    `form:"maxDownloadConcurrency" json:"maxDownloadConcurrency" query:"maxDownloadConcurrency"`
 }
 
 var searchOptions = map[string]string{

--- a/controllers/pages.go
+++ b/controllers/pages.go
@@ -31,6 +31,7 @@ type SettingModel struct {
 	GenerateNFOFile               bool   `form:"generateNFOFile" json:"generateNFOFile" query:"generateNFOFile"`
 	DontDownloadDeletedFromDisk   bool   `form:"dontDownloadDeletedFromDisk" json:"dontDownloadDeletedFromDisk" query:"dontDownloadDeletedFromDisk"`
 	BaseUrl                       string `form:"baseUrl" json:"baseUrl" query:"baseUrl"`
+	MaxDownloadConcurrency        bool   `form:"maxDownloadConcurrency" json:"maxDownloadConcurrency" query:"maxDownloadConcurrency"`
 }
 
 var searchOptions = map[string]string{

--- a/controllers/pages.go
+++ b/controllers/pages.go
@@ -32,6 +32,7 @@ type SettingModel struct {
 	DontDownloadDeletedFromDisk   bool   `form:"dontDownloadDeletedFromDisk" json:"dontDownloadDeletedFromDisk" query:"dontDownloadDeletedFromDisk"`
 	BaseUrl                       string `form:"baseUrl" json:"baseUrl" query:"baseUrl"`
 	MaxDownloadConcurrency        int    `form:"maxDownloadConcurrency" json:"maxDownloadConcurrency" query:"maxDownloadConcurrency"`
+	UserAgent                     string `form:"userAgent" json:"userAgent" query:"userAgent"`
 }
 
 var searchOptions = map[string]string{

--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -629,7 +629,7 @@ func UpdateSetting(c *gin.Context) {
 		err = service.UpdateSettings(model.DownloadOnAdd, model.InitialDownloadCount,
 			model.AutoDownload, model.AppendDateToFileName, model.AppendEpisodeNumberToFileName,
 			model.DarkMode, model.DownloadEpisodeImages, model.GenerateNFOFile, model.DontDownloadDeletedFromDisk, model.BaseUrl,
-			model.MaxDownloadConcurrency,
+			model.MaxDownloadConcurrency, model.UserAgent,
 		)
 		if err == nil {
 			c.JSON(200, gin.H{"message": "Success"})

--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -628,7 +628,9 @@ func UpdateSetting(c *gin.Context) {
 
 		err = service.UpdateSettings(model.DownloadOnAdd, model.InitialDownloadCount,
 			model.AutoDownload, model.AppendDateToFileName, model.AppendEpisodeNumberToFileName,
-			model.DarkMode, model.DownloadEpisodeImages, model.GenerateNFOFile, model.DontDownloadDeletedFromDisk, model.BaseUrl)
+			model.DarkMode, model.DownloadEpisodeImages, model.GenerateNFOFile, model.DontDownloadDeletedFromDisk, model.BaseUrl,
+			model.MaxDownloadConcurrency
+		)
 		if err == nil {
 			c.JSON(200, gin.H{"message": "Success"})
 

--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -629,7 +629,7 @@ func UpdateSetting(c *gin.Context) {
 		err = service.UpdateSettings(model.DownloadOnAdd, model.InitialDownloadCount,
 			model.AutoDownload, model.AppendDateToFileName, model.AppendEpisodeNumberToFileName,
 			model.DarkMode, model.DownloadEpisodeImages, model.GenerateNFOFile, model.DontDownloadDeletedFromDisk, model.BaseUrl,
-			model.MaxDownloadConcurrency
+			model.MaxDownloadConcurrency,
 		)
 		if err == nil {
 			c.JSON(200, gin.H{"message": "Success"})

--- a/db/podcast.go
+++ b/db/podcast.go
@@ -88,6 +88,7 @@ type Setting struct {
 	DontDownloadDeletedFromDisk   bool `gorm:"default:false"`
 	BaseUrl                       string
 	MaxDownloadConcurrency        int `gorm:"default:5"`
+	UserAgent                     string
 }
 type Migration struct {
 	Base

--- a/db/podcast.go
+++ b/db/podcast.go
@@ -87,6 +87,7 @@ type Setting struct {
 	GenerateNFOFile               bool `gorm:"default:false"`
 	DontDownloadDeletedFromDisk   bool `gorm:"default:false"`
 	BaseUrl                       string
+	MaxDownloadConcurrency        int `gorm:"default:5"`
 }
 type Migration struct {
 	Base

--- a/service/fileService.go
+++ b/service/fileService.go
@@ -28,8 +28,7 @@ func Download(link string, episodeTitle string, podcastName string, prefix strin
 	}
 	client := httpClient()
 
-	req, err := http.NewRequest("GET", link, nil)
-	req.Header.Add("User-Agent", "")
+	req, err := getRequest(link)
 	if err != nil {
 		Logger.Errorw("Error creating request: "+link, err)
 	}

--- a/service/fileService.go
+++ b/service/fileService.go
@@ -27,7 +27,14 @@ func Download(link string, episodeTitle string, podcastName string, prefix strin
 		return "", errors.New("Download path empty")
 	}
 	client := httpClient()
-	resp, err := client.Get(link)
+
+	req, err := http.NewRequest("GET", link, nil)
+	req.Header.Add("User-Agent", "")
+	if err != nil {
+		Logger.Errorw("Error creating request: "+link, err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		Logger.Errorw("Error getting response: "+link, err)
 		return "", err
@@ -102,7 +109,13 @@ func DownloadPodcastCoverImage(link string, podcastName string) (string, error) 
 		return "", errors.New("Download path empty")
 	}
 	client := httpClient()
-	resp, err := client.Get(link)
+	req, err := getRequest(link)
+	if err != nil {
+		Logger.Errorw("Error creating request: "+link, err)
+		return "", err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		Logger.Errorw("Error getting response: "+link, err)
 		return "", err
@@ -139,7 +152,13 @@ func DownloadImage(link string, episodeId string, podcastName string) (string, e
 		return "", errors.New("Download path empty")
 	}
 	client := httpClient()
-	resp, err := client.Get(link)
+	req, err := getRequest(link)
+	if err != nil {
+		Logger.Errorw("Error creating request: "+link, err)
+		return "", err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		Logger.Errorw("Error getting response: "+link, err)
 		return "", err
@@ -324,6 +343,20 @@ func httpClient() *http.Client {
 	}
 
 	return &client
+}
+
+func getRequest(url string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	setting := db.GetOrCreateSetting()
+	if len(setting.UserAgent) > 0 {
+		req.Header.Add("User-Agent", setting.UserAgent)
+	}
+
+	return req, nil
 }
 
 func createFolder(folder string, parent string) string {

--- a/service/podcastService.go
+++ b/service/podcastService.go
@@ -764,7 +764,7 @@ func GetSearchFromPodcastIndex(pod *podcastindex.Podcast) *model.CommonSearchRes
 
 func UpdateSettings(downloadOnAdd bool, initialDownloadCount int, autoDownload bool,
 	appendDateToFileName bool, appendEpisodeNumberToFileName bool, darkMode bool, downloadEpisodeImages bool,
-	generateNFOFile bool, dontDownloadDeletedFromDisk bool, baseUrl string, maxDownloadConcurrency int) error {
+	generateNFOFile bool, dontDownloadDeletedFromDisk bool, baseUrl string, maxDownloadConcurrency int, userAgent string) error {
 	setting := db.GetOrCreateSetting()
 
 	setting.AutoDownload = autoDownload
@@ -778,6 +778,7 @@ func UpdateSettings(downloadOnAdd bool, initialDownloadCount int, autoDownload b
 	setting.DontDownloadDeletedFromDisk = dontDownloadDeletedFromDisk
 	setting.BaseUrl = baseUrl
 	setting.MaxDownloadConcurrency = maxDownloadConcurrency
+	setting.UserAgent = userAgent
 
 	return db.UpdateSettings(setting)
 }

--- a/service/podcastService.go
+++ b/service/podcastService.go
@@ -537,7 +537,7 @@ func DownloadMissingEpisodes() error {
 			SetPodcastItemAsDownloaded(item.ID, url)
 		}(item, *setting)
 
-		if index%5 == 0 {
+		if index%setting.MaxDownloadConcurrency == 0 {
 			wg.Wait()
 		}
 	}
@@ -764,7 +764,7 @@ func GetSearchFromPodcastIndex(pod *podcastindex.Podcast) *model.CommonSearchRes
 
 func UpdateSettings(downloadOnAdd bool, initialDownloadCount int, autoDownload bool,
 	appendDateToFileName bool, appendEpisodeNumberToFileName bool, darkMode bool, downloadEpisodeImages bool,
-	generateNFOFile bool, dontDownloadDeletedFromDisk bool, baseUrl string) error {
+	generateNFOFile bool, dontDownloadDeletedFromDisk bool, baseUrl string, maxDownloadConcurrency int) error {
 	setting := db.GetOrCreateSetting()
 
 	setting.AutoDownload = autoDownload
@@ -777,6 +777,7 @@ func UpdateSettings(downloadOnAdd bool, initialDownloadCount int, autoDownload b
 	setting.GenerateNFOFile = generateNFOFile
 	setting.DontDownloadDeletedFromDisk = dontDownloadDeletedFromDisk
 	setting.BaseUrl = baseUrl
+	setting.MaxDownloadConcurrency = maxDownloadConcurrency
 
 	return db.UpdateSettings(setting)
 }


### PR DESCRIPTION
Adds two new settings that can give greater control over how podcasts are downloaded:

- Max download concurrency (default=5).
- User-Agent header (default=go http library default).

This has enabled me to download podcasts that might throttle higher parallelism or "known" http-library user agent header.

Preview of how the new options render:
![image](https://user-images.githubusercontent.com/17959254/189917827-36fe01e4-5a7e-4efa-8958-acd91144a6e6.png)
